### PR TITLE
Fixing PlainAdams initializer

### DIFF
--- a/radam.py
+++ b/radam.py
@@ -82,10 +82,10 @@ class PlainRAdam(Optimizer):
     def __init__(self, params, lr=1e-3, betas=(0.9, 0.999), eps=1e-8, weight_decay=0):
         defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
 
-        super(RAdam, self).__init__(params, defaults)
+        super(PlainRAdam, self).__init__(params, defaults)
 
     def __setstate__(self, state):
-        super(RAdam, self).__setstate__(state)
+        super(PlainRAdam, self).__setstate__(state)
 
     def step(self, closure=None):
 


### PR DESCRIPTION
Call to supers __init__ and __setstate__ methods have been fixed.