### PR TITLE
'async' is a reserved word in Python >= 3.7

### DIFF
--- a/cifar_imagenet/cifar.py
+++ b/cifar_imagenet/cifar.py
@@ -265,7 +265,7 @@ def train(trainloader, model, criterion, optimizer, epoch, use_cuda):
         data_time.update(time.time() - end)
 
         if use_cuda:
-            inputs, targets = inputs.cuda(), targets.cuda(async=True)
+            inputs, targets = inputs.cuda(), targets.cuda(non_blocking=True)
         inputs, targets = torch.autograd.Variable(inputs), torch.autograd.Variable(targets)
 
         # compute output

--- a/cifar_imagenet/imagenet.py
+++ b/cifar_imagenet/imagenet.py
@@ -258,7 +258,7 @@ def train(train_loader, model, criterion, optimizer, epoch, use_cuda):
         data_time.update(time.time() - end)
 
         if use_cuda:
-            inputs, targets = inputs.cuda(), targets.cuda(async=True)
+            inputs, targets = inputs.cuda(), targets.cuda(non_blocking=True)
         inputs, targets = torch.autograd.Variable(inputs), torch.autograd.Variable(targets)
 
         # compute output
@@ -364,4 +364,3 @@ def adjust_learning_rate(optimizer, epoch):
 if __name__ == '__main__':
     main()
     # writer.close()
-    

--- a/cifar_imagenet/utils/misc.py
+++ b/cifar_imagenet/utils/misc.py
@@ -9,6 +9,7 @@ import sys
 import time
 import math
 
+import torch
 import torch.nn as nn
 import torch.nn.init as init
 from torch.autograd import Variable


### PR DESCRIPTION
__async__ is a reserved word in Python 3.7 and later.  To fix this pytorch/pytorch#4999 changed __cuda(async=True)__ to __cuda(non_blocking=True)__ so this PR tracks with that change.  That fix landed in PyTourch 0.4.1.

Also __import torch__ to avoid three undefined names.

[flake8](http://flake8.pycqa.org) testing of https://github.com/LiyuanLucasLiu/RAdam on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./language-model/model_word_ada/utils.py:16:12: F821 undefined name 'is_sparse'
        if is_sparse(p.grad):
           ^
./language-model/model_word_ada/utils.py:27:16: F821 undefined name 'is_sparse'
            if is_sparse(p.grad):
               ^
./cifar_imagenet/imagenet.py:261:63: E999 SyntaxError: invalid syntax
            inputs, targets = inputs.cuda(), targets.cuda(async=True)
                                                              ^
./cifar_imagenet/cifar.py:268:63: E999 SyntaxError: invalid syntax
            inputs, targets = inputs.cuda(), targets.cuda(async=True)
                                                              ^
./cifar_imagenet/utils/misc.py:21:32: F821 undefined name 'torch'
    dataloader = trainloader = torch.utils.data.DataLoader(dataset, batch_size=1, shuffle=True, num_workers=2)
                               ^
./cifar_imagenet/utils/misc.py:23:12: F821 undefined name 'torch'
    mean = torch.zeros(3)
           ^
./cifar_imagenet/utils/misc.py:24:11: F821 undefined name 'torch'
    std = torch.zeros(3)
          ^
2     E999 SyntaxError: invalid syntax
5     F821 undefined name 'torch'
7
```