### PR TITLE
Renaming AdamW to RAdamW

### DIFF
--- a/radam.py
+++ b/radam.py
@@ -142,15 +142,15 @@ class PlainRAdam(Optimizer):
         return loss
 
 
-class AdamW(Optimizer):
+class RAdamW(Optimizer):
 
     def __init__(self, params, lr=1e-3, betas=(0.9, 0.999), eps=1e-8, weight_decay=0, warmup = 0):
         defaults = dict(lr=lr, betas=betas, eps=eps,
                         weight_decay=weight_decay, warmup = warmup)
-        super(AdamW, self).__init__(params, defaults)
+        super(RAdamW, self).__init__(params, defaults)
 
     def __setstate__(self, state):
-        super(AdamW, self).__setstate__(state)
+        super(RAdamW, self).__setstate__(state)
 
     def step(self, closure=None):
         loss = None


### PR DESCRIPTION
I think the AdamW name is misleading.
First of all, this is the rectified version, as far as i understood,
second, the Pytorch library already has an AdamW optimizer, so 
it might be confusing to have another optimizer with the same name.
So my proposal is to rename it from AdamW to RAdamW.