### PR TITLE
buffer bug fix

### DIFF
--- a/radam.py
+++ b/radam.py
@@ -15,8 +15,11 @@ class RAdam(Optimizer):
             raise ValueError("Invalid beta parameter at index 1: {}".format(betas[1]))
         
         self.degenerated_to_sgd = degenerated_to_sgd
-        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
-        self.buffer = [[None, None, None] for ind in range(10)]
+        if isinstance(params, (list, tuple)) and len(params) > 0 and isinstance(params[0], dict):
+            for param in params:
+                if 'betas' in param and (param['betas'][0] != betas[0] or param['betas'][1] != betas[1]):
+                    param['buffer'] = [[None, None, None] for _ in range(10)]
+        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay, buffer=[[None, None, None] for _ in range(10)])
         super(RAdam, self).__init__(params, defaults)
 
     def __setstate__(self, state):
@@ -56,7 +59,7 @@ class RAdam(Optimizer):
                 exp_avg.mul_(beta1).add_(1 - beta1, grad)
 
                 state['step'] += 1
-                buffered = self.buffer[int(state['step'] % 10)]
+                buffered = group['buffer'][int(state['step'] % 10)]
                 if state['step'] == buffered[0]:
                     N_sma, step_size = buffered[1], buffered[2]
                 else:


### PR DESCRIPTION
Hello!
Thank you for your wonderful paper and code.
I found a bug in your RAdam code.
When i tested RAdam using following code, it got wrong results because RAdam class has only one caching storage.
```
def run(optimizer_class, warmup=0):
    p = torch.nn.Parameter(torch.ones(1))
    l = torch.nn.Parameter(torch.ones(1))
    q = torch.nn.Parameter(torch.ones(1))
    m = torch.nn.Parameter(torch.ones(1))
    t = [
        {'params': [p], 'betas': (0.9, 0.999)},
        {'params': [l], 'betas': (0.9, 0.1)},
        {'params': [q]},
        {'params': [m], 'betas': (0.1, 0.999)}
    ]
    o = optimizer_class(t)

    for _ in range(10):
        (p + l + q + m).backward()
        o.step()
        o.zero_grad()
    return p.item(), l.item(), q.item(), m.item()

print('PlainRAdam', run(PlainRAdam))
print('RAdam', run(RAdam))
# PlainRAdam (0.9948096871376038, 0.9900001287460327, 0.9948096871376038, 0.9948096871376038)
# RAdam (0.9948096871376038, 0.9949827790260315, 0.9948096871376038, 0.976420521736145)
```
My pull request fixes this issue.